### PR TITLE
Cherry pick valyala/fastjson/pull/87

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -267,28 +267,41 @@ func parseObject(s string, c *cache, depth int) (*Value, string, error) {
 }
 
 func escapeString(dst []byte, s string) []byte {
-	if !hasSpecialChars(s) {
-		// Fast path - nothing to escape.
-		dst = append(dst, '"')
-		dst = append(dst, s...)
-		dst = append(dst, '"')
-		return dst
-	}
-
-	// Slow path.
-	return strconv.AppendQuote(dst, s)
-}
-
-func hasSpecialChars(s string) bool {
-	if strings.IndexByte(s, '"') >= 0 || strings.IndexByte(s, '\\') >= 0 {
-		return true
-	}
+	dst = append(dst, '"')
 	for i := 0; i < len(s); i++ {
-		if s[i] < 0x20 {
-			return true
+		c := s[i]
+		switch {
+		case c == '"':
+			// quotation mark
+			dst = append(dst, []byte{'\\', '"'}...)
+		case c == '\\':
+			// reverse solidus
+			dst = append(dst, []byte{'\\', '\\'}...)
+		case c >= 0x20:
+			// default, rest below are control chars
+			dst = append(dst, c)
+		case c == 0x08:
+			dst = append(dst, []byte{'\\', 'b'}...)
+		case c < 0x09:
+			dst = append(dst, []byte{'\\', 'u', '0', '0', '0', '0' + c}...)
+		case c == 0x09:
+			dst = append(dst, []byte{'\\', 't'}...)
+		case c == 0x0a:
+			dst = append(dst, []byte{'\\', 'n'}...)
+		case c == 0x0c:
+			dst = append(dst, []byte{'\\', 'f'}...)
+		case c == 0x0d:
+			dst = append(dst, []byte{'\\', 'r'}...)
+		case c < 0x10:
+			dst = append(dst, []byte{'\\', 'u', '0', '0', '0', 0x57 + c}...)
+		case c < 0x1a:
+			dst = append(dst, []byte{'\\', 'u', '0', '0', '1', 0x20 + c}...)
+		case c < 0x20:
+			dst = append(dst, []byte{'\\', 'u', '0', '0', '1', 0x47 + c}...)
 		}
 	}
-	return false
+	dst = append(dst, '"')
+	return dst
 }
 
 func unescapeStringBestEffort(s string) string {


### PR DESCRIPTION
Fixes non-printable UTF-8 fastjson artifacts.

This is a cherry-pick of the PR https://github.com/valyala/fastjson/pull/87 that fixes issue https://github.com/valyala/fastjson/issues/90

Note that in order to trigger this bug when actually Parsing a json payload (instead of just using a string as displayed in the description of https://github.com/valyala/fastjson/issues/90) you need to `Visit()` the problematic string key and do `Type()` on it. [`Type()` has side effects.](https://github.com/valyala/fastjson/blob/93f67d942133e9d219dbbae7a541433f8bbbe7c4/parser.go#L678-L683)

There is also an extra commit with tests that break without the changes.